### PR TITLE
ビルドエラーを解消

### DIFF
--- a/project/data/data.bin
+++ b/project/data/data.bin
@@ -1,1 +1,1 @@
-{"Key_FieldLevel":0,"Key_RemainTime":5291}
+{"Key_FieldLevel":0,"Key_RemainTime":5400}

--- a/project/source/Viewer/GameScene/Controller/GameViewer.cpp
+++ b/project/source/Viewer/GameScene/Controller/GameViewer.cpp
@@ -14,6 +14,11 @@
 #include "../ParameterContainer/GameViewerParam.h"
 #include "GameViewer.h"
 
+#ifdef _DEBUG
+#include "../../../../Framework/Input/input.h"
+#include "../../../../Framework/Tool/DebugWindow.h"
+#endif
+
 //*****************************************************************************
 // コンストラクタ
 //*****************************************************************************


### PR DESCRIPTION
オートマージ時にGameVeiwer.cppのdebugのincludeが削除されてマージされたためにビルドエラーが出ていたのを解消。